### PR TITLE
BAC-3220: add field forAccessLevelValue for switch in permission settings

### DIFF
--- a/src/@model/permission.ts
+++ b/src/@model/permission.ts
@@ -49,11 +49,13 @@ interface PermissionUpdatableInput extends PermissionInput {
   readonly addiction?: PermissionInput[]
   readonly trigger?: PermissionTriggerInput[]
   readonly notAccessLevel?: number[]
+  readonly forAccessLevelValue?: number
 }
 export class PermissionUpdatableTable extends Permission implements PermissionUpdatableInput {
   readonly type: PermissionUpdatableType
   readonly trigger?: PermissionTriggerInput[]
   readonly notAccessLevel?: number[]
+  readonly forAccessLevelValue?: number
 
   constructor(data: PermissionUpdatableInput) {
     super({ ...data, access: data.access ? data.access : 0 })
@@ -61,6 +63,7 @@ export class PermissionUpdatableTable extends Permission implements PermissionUp
     this.type = data.type
     this.trigger = data.trigger || []
     this.notAccessLevel = data.notAccessLevel || [0]
+    this.forAccessLevelValue = data?.forAccessLevelValue ?? 0
   }
 }
 export class PermissionUpdatableTableList {

--- a/src/components/permitionsForm/GroupFragmentSettingsTable.vue
+++ b/src/components/permitionsForm/GroupFragmentSettingsTable.vue
@@ -54,7 +54,7 @@ const searchLevel = (permission: PermissionUpdatableTable, val: string) => {
 const getMaxValue = (permission: PermissionUpdatableTable) => {
   switch (permission.type) {
     case 'switch':
-      return 1
+      return permission?.forAccessLevelValue || 1
     case 'table':
       return searchLevel(permission, tableColumns.value[tableColumns.value.length - 1].key)
   }
@@ -134,8 +134,9 @@ const onChangeTrigger = (
   })
 }
 
-const onChangeCheckbox = (permission: PermissionUpdatableTable, isCheck: boolean) => {
-  const level = isCheck ? 1 : 0
+const onChangeSwitch = (permission: PermissionUpdatableTable, isCheck: boolean) => {
+  const itemPermissionLevel = permission?.forAccessLevelValue || 1
+  const level = isCheck ? itemPermissionLevel : 0
 
   changeAccess(permission, level)
   onChangeTrigger(permission)
@@ -263,7 +264,7 @@ const onChangeCheckboxTable = (
                 :model-value="switchItem.access > 0"
                 class="ml-0"
                 :label="$t(`permission.${switchItem.target}`)"
-                @update:model-value="onChangeCheckbox(switchItem, $event)"
+                @update:model-value="onChangeSwitch(switchItem, $event)"
               />
             </VRow>
           </div>


### PR DESCRIPTION
An additional field for permission settings with a switch type was created.

Field name: "forAccessLevelValue"

When toggled on, this field sets the value of "forAccessLevelValue" to true.