### PR TITLE
BAC-4304 preload options for select

### DIFF
--- a/src/@model/templates/baseField/base.ts
+++ b/src/@model/templates/baseField/base.ts
@@ -111,7 +111,7 @@ export abstract class ASelectBaseField<T extends OptionsItem = OptionsItem>
         const { list: selectedOptions } = await store.dispatch(this.fetchOptionsActionName, {
           perPage: 50,
           filter: {
-            ids: Array.isArray(this.value) ? this.value.map(item => item?.id || item) : [this.value],
+            ids: Array.isArray(this.value) ? this.value.map(item => item?.id || item) : [this.value?.id],
           },
         })
 

--- a/src/@model/templates/baseField/base.ts
+++ b/src/@model/templates/baseField/base.ts
@@ -107,11 +107,12 @@ export abstract class ASelectBaseField<T extends OptionsItem = OptionsItem>
 
   async fetchOptions(search: string) {
     if (this.fetchOptionsActionName) {
-      if (this.preloadOptionsByIds && this.value?.length && search === undefined) {
+      const isExistsValue = this.value?.length || this.value?.id
+      if (this.preloadOptionsByIds && isExistsValue && search === undefined) {
         const { list: selectedOptions } = await store.dispatch(this.fetchOptionsActionName, {
           perPage: 50,
           filter: {
-            ids: Array.isArray(this.value) ? this.value.map(item => item?.id || item) : [this.value?.id],
+            ids: Array.isArray(this.value) ? this.value.map(item => item?.id || item) : [this.value?.id || this.value],
           },
         })
 

--- a/src/@model/templates/baseField/base.ts
+++ b/src/@model/templates/baseField/base.ts
@@ -111,7 +111,7 @@ export abstract class ASelectBaseField<T extends OptionsItem = OptionsItem>
         const { list: selectedOptions } = await store.dispatch(this.fetchOptionsActionName, {
           perPage: 50,
           filter: {
-            ids: this.value.map(item => item?.id || item),
+            ids: Array.isArray(this.value) ? this.value.map(item => item?.id || item) : [this.value],
           },
         })
 

--- a/tests/unit/templates/FieldGenerator/MultiSelectField.spec.ts
+++ b/tests/unit/templates/FieldGenerator/MultiSelectField.spec.ts
@@ -8,7 +8,7 @@ import {
   checkImmediateFetchOnEmptyOptions,
   checkLoadingStateInput,
   checkOptionSearchActions, checkOptionsLength,
-  checkPlaceholderStatesAndFilter, defaultPropsSelect, field, openDropDownMenuOfSelector,
+  checkPlaceholderStatesAndFilter, checkPreloadOptionsByIds, defaultPropsSelect, field, openDropDownMenuOfSelector,
   options,
   setMountComponentSelect,
 } from '../shared-tests/select-field'
@@ -105,5 +105,21 @@ describe('MultiSelectField', () => {
     const wrapper = getMountMultiSelectField(props)
 
     await checkDisabledStateByProps(wrapper, { selector: '.vs--multiple' })
+  })
+
+  it('Fetch options (preload values) with correct filter.ids when value is an array of objects', async () => {
+    const wrapper = getMountMultiSelectField(props)
+
+    await checkPreloadOptionsByIds(wrapper, {
+      value: [
+        { id: '1', name: 'Option 1' },
+        { id: '2', name: 'Option 2' },
+      ],
+      field: {
+        ...props.field,
+        preloadOptionsByIds: true,
+      },
+      expectedIds: ['1', '2'],
+    })
   })
 })

--- a/tests/unit/templates/FieldGenerator/SelectField.spec.ts
+++ b/tests/unit/templates/FieldGenerator/SelectField.spec.ts
@@ -6,7 +6,7 @@ import {
   checkImmediateFetchOnEmptyOptions,
   checkLoadingStateInput,
   checkOptionSearchActions, checkOptionsLength,
-  checkPlaceholderStatesAndFilter, defaultPropsSelect, field,
+  checkPlaceholderStatesAndFilter, checkPreloadOptionsByIds, defaultPropsSelect, field,
   options,
   setMountComponentSelect,
 } from '../shared-tests/select-field'
@@ -85,5 +85,18 @@ describe('SelectField', () => {
     const wrapper = getMountSelectField(props)
 
     await checkDisabledStateByProps(wrapper, { selector: '.select-field' })
+  })
+
+  it('Fetch options (preload values) with correct filter.ids when value is an object', async () => {
+    const wrapper = getMountSelectField(props)
+
+    await checkPreloadOptionsByIds(wrapper, {
+      value: { id: '1', name: 'Option 1' },
+      field: {
+        ...props.field,
+        preloadOptionsByIds: true,
+      },
+      expectedIds: ['1'],
+    })
   })
 })

--- a/tests/unit/templates/shared-tests/select-field.ts
+++ b/tests/unit/templates/shared-tests/select-field.ts
@@ -119,3 +119,26 @@ export const checkDisabledStateByProps = async (wrapper: VueWrapper, { selector 
   /// Disabled props true
   testOn.existClass({ wrapper, selector }, expectedClass)
 }
+
+export const checkPreloadOptionsByIds = async (wrapper: VueWrapper, { value, field, expectedIds }: { value: OptionsItem | OptionsItem[]; field: SelectField; expectedIds: string[] }) => {
+  expect(wrapper.vm.isLoading).toBe(false)
+
+  await wrapper.setProps({
+    modelValue: value,
+    field: {
+      ...field,
+      preloadOptionsByIds: true,
+      options: null,
+      fetchOptions: async () =>
+        new Promise(resolve => setTimeout(() => resolve(expectedIds), 100)),
+    },
+  })
+
+  await nextTick()
+  expect(wrapper.vm.isLoading).toBe(true)
+
+  await new Promise(resolve => setTimeout(resolve, 150))
+  await nextTick()
+
+  expect(wrapper.vm.isLoading).toBe(false)
+}


### PR DESCRIPTION
Для `SelectBaseField` класса можно также передавать `preloadOptionsByIds: true` чтобы предзагрузить selected ids если это поддерживает эндпоинт