### PR TITLE
BAC-5181: Adds token refresh functionality.

### DIFF
--- a/src/services/ws/index.ts
+++ b/src/services/ws/index.ts
@@ -15,20 +15,30 @@ class WSService {
   static WSListSubscribe: Set<string> = new Set()
   static WSchannel: null
 
-  static async connect(channel) {
+  static async connect(channel, needRefresh = false) {
     this.WSchannel = channel
-    if (!checkIsLoggedIn() || !getAccessToken())
+    if (!checkIsLoggedIn() || !getAccessToken() || !getRefreshToken())
       return
+
+    async function getToken() {
+      const data: {
+        accessToken: string
+        refreshToken: string
+      } = await store.dispatch('authCore/refreshAuth', getRefreshToken())
+
+      return data?.accessToken
+    }
+
+    let refreshAuthToken = null
+    if (needRefresh)
+      refreshAuthToken = await getToken()
 
     // ws://localhost:56316/connection/websocket (lens link port)
     // wss://${location.host || location.hostname}/ws
     const client = new Centrifuge(`wss://${location.host || location.hostname}/ws`, {
-      token: getAccessToken(),
       debug: true,
-      async onRefresh(ctx, cb) {
-        await store.dispatch('authCore/refreshAuth', getRefreshToken())
-        cb({ token: getAccessToken() })
-      },
+      token: refreshAuthToken || getAccessToken(),
+      getToken,
     })
 
     if (channel) {
@@ -43,11 +53,12 @@ class WSService {
 
     client.on('error', async ctx => {
       console.log(ctx?.error?.message ? `ERROR: ${ctx?.error?.message} / Type: ${ctx?.type}` : ctx)
-      await store.dispatch('authCore/refreshAuth', getRefreshToken())
 
       if (ctx?.error?.code === 109 || ctx?.error?.message === 'token expired') {
-        if (WSService.WSchannel)
-          WSService.connect(WSService.WSchannel)
+        if (WSService.WSchannel) {
+          WSService.disconnect()
+          WSService.connect(WSService.WSchannel, true)
+        }
       }
     })
 
@@ -68,7 +79,7 @@ class WSService {
       WSService.parseData(JSON.parse(ctx.data))
     })
 
-    client.on('connecting', ctx => {
+    client.on('connecting', async ctx => {
       console.log('connecting', ctx)
     })
 

--- a/src/services/ws/index.ts
+++ b/src/services/ws/index.ts
@@ -25,6 +25,10 @@ class WSService {
     const client = new Centrifuge(`wss://${location.host || location.hostname}/ws`, {
       token: getAccessToken(),
       debug: true,
+      async onRefresh(ctx, cb) {
+        await store.dispatch('authCore/refreshAuth', getRefreshToken())
+        cb({ token: getAccessToken() })
+      },
     })
 
     if (channel) {


### PR DESCRIPTION
https://upstars.atlassian.net/browse/BAC-5181
Adds a token refresh mechanism to the websocket service.

This ensures the websocket connection remains authenticated by refreshing the access token when necessary.